### PR TITLE
generalized download script to arbitrary databases from NCBI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,37 @@
 BLAST Download
 ==============
 
-Downloads NCBI's BLAST databases. Originally intended for High-Performance Cluster systems to provide the databases within globally readable shares so all user groups can access the same databases.
+Downloads data from NCBI's ftp server (e.g., BLAST databases). Originally intended for High-Performance Cluster systems to provide the databases within globally readable shares so all user groups can access the same databases.
+
+Usage
+-----
+
+```
+blastdl.sh REMOTE_DIR PATTERN LOCAL_DIR
+```
+
+Will download `ftp://ftp.ncbi.nlm.nih.gov/REMOTE_DIR/PATTERN*.tar.gz` into `LOCAL_DIR/PATTERN/DATE` where `DATE` is the current date in format YYYY-MM-DD. A symbolic link `LOCAL_DIR/PATTERN/latest` pointing to `LOCAL_DIR/PATTERN/DATE` will be created/updated.
+
+Intended to be used as cron jobs, e.g.:
+
+```
+@monthly time /path/to/blastdl/blastdl.sh blast/db/ nr /data/db/blast
+@monthly time /path/to/blastdl/blastdl.sh blast/db/ nt /data/db/blast
+```
 
 Features
 --------
 
--   existing files are not overwritten
+-   Existing files are not overwritten (if the directory LOCAL_DIR/PATTERN/DATE already exists the script will fail).  
 
-    All running jobs would have inconsistent results if files would be updated in place.
-    
--   downloaded datasets are tagged with the download date
-    
-    Each consistent download is tagged with the local date of the download. You can access these datasets via:
-    
-        blastn -db /data/db/blast/nt-2016-09-01 ...
-        
+    Hence, all running jobs would have inconsistent results if files would be updated in place.
+
+-   downloaded datasets are accessible by the download date
+
+    For instance, for blast can access these datasets via:
+
+        blastn -db /data/db/blast/2016-09-01/nt ...
+
     This also allows for **reproducible research**, which you would not be able to do with in place updates of the database files.
 
 -   md5s are rigorously checked
@@ -25,7 +41,7 @@ Features
 -   you can specify the download directory
 
     Intended to be a globally readable share. This way, all users can access the same files instead of having to download the files to their individual personal or group directories. This approach has a few advantages:
-    
+
     - no user or group quotas are utilized
     - a single copy of the database, not multiple copies for each user or group
     - a single copy can also be cached better, thus provided faster by the cluster file system, which would not be the case with individual copies
@@ -36,12 +52,3 @@ Features
 
         journalctl -t blastdl
 
-Usage
------
-
-Intended to be used as cron jobs, e.g.:
-
-```
-@monthly time bash /path/to/blastdl/blastdl.sh nr /data/db/blast
-@monthly time bash /path/to/blastdl/blastdl.sh nt /data/db/blast
-```

--- a/blastdl.sh
+++ b/blastdl.sh
@@ -8,7 +8,7 @@ umask 0022
 
 function usage {
   echo "usage: bash $0 rdir dbname ldir"
-  echo "- will download rdir/dbname*.tar.gz from the NCBI ftp to ldir/YYYY-MM-DD"
+  echo "- will download rdir/dbname*.tar.gz from the NCBI ftp to ldir/dbname/YYYY-MM-DD"
 }
 
 # parse command line arguments (and make sure that they are set and useful)
@@ -30,8 +30,9 @@ LOCAL_DIR=$3
   exit 1
 }
 
+mkdir -f $LOCAL_DIR/$DB_NAME
 # create temp directory within the LOCAL_DIR and make sure its deleted on exit
-TMP_DIR=$(mktemp -d --tmpdir=$LOCAL_DIR .blastdl-XXXXXXXXXX)
+TMP_DIR=$(mktemp -d --tmpdir=$LOCAL_DIR/$DBNAME .blastdl-XXXXXXXXXX)
 trap 'rm -rf $TMP_DIR' EXIT INT TERM
 
 DATE=$(date +%F)
@@ -74,10 +75,10 @@ for i in $DB_NAME*.tar.gz ; do
 done &&
 log.info "... extracting finished, tagging with date and moving ..." &&
 for i in $DB_NAME.* ; do
-  mv -n $i $LOCAL_DIR/$DATE/ || exit 1
+  mv -n $i $LOCAL_DIR/$DB_NAME/$DATE/ || exit 1
 done &&
-rm -rf $LOCAL_DIR/latest
-ln -s $LOCAL_DIR/$DATE/ $LOCAL_DIR/latest
+rm -rf $LOCAL_DIR/$DB_NAME/latest
+ln -s $LOCAL_DIR/$DB_NAME/$DATE/ $LOCAL_DIR/$DB_NAME/latest
 log.info "... moving done, setting read only ..." &&
 chmod -R 444 $LOCAL_DIR/$DB_NAME/$DATE/ &&
 log.info "... set read only, done." &&

--- a/blastdl.sh
+++ b/blastdl.sh
@@ -12,6 +12,7 @@ function usage {
 }
 
 # parse command line arguments (and make sure that they are set and useful)
+echo $1 $2 $3
 REMOTE_DIR=$1
 [[ -n $REMOTE_DIR ]] || {
   usage >&2
@@ -26,11 +27,13 @@ DB_NAME=$2
 
 LOCAL_DIR=$3
 [[ -d $LOCAL_DIR ]] || {
+  echo "no such file or directory "$LOCAL_DIR >&2
   usage >&2
   exit 1
 }
 
-mkdir -f $LOCAL_DIR/$DB_NAME
+
+mkdir -p $LOCAL_DIR/$DB_NAME
 # create temp directory within the LOCAL_DIR and make sure its deleted on exit
 TMP_DIR=$(mktemp -d --tmpdir=$LOCAL_DIR/$DBNAME .blastdl-XXXXXXXXXX)
 trap 'rm -rf $TMP_DIR' EXIT INT TERM
@@ -79,7 +82,7 @@ for i in $DB_NAME.* ; do
 done &&
 rm -rf $LOCAL_DIR/$DB_NAME/latest
 ln -s $LOCAL_DIR/$DB_NAME/$DATE/ $LOCAL_DIR/$DB_NAME/latest
-log.info "... moving done, setting read only ..." &&
-chmod -R 444 $LOCAL_DIR/$DB_NAME/$DATE/ &&
-log.info "... set read only, done." &&
+# log.info "... moving done, setting read only ..." &&
+# chmod -R 444 $LOCAL_DIR/$DB_NAME/$DATE/ &&
+# log.info "... set read only, done." &&
 popd &> /dev/null

--- a/diamond.sh
+++ b/diamond.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# - download nr as fasta from ncbi 
+# - download ncbi taxonomy dump and protein accession->taxid mappings from ncbi
+# - make diamond db
+# - remove fasta data
+
+./ncbidl.sh blast/db/FASTA pdbnt diamonddb/
+./ncbidl.sh pub/taxonomy/ taxdump taxonomy/ncbi/
+./ncbidl.sh pub/taxonomy/accession2taxid prot.accession2taxid.gz taxonomy/ncbi/
+
+# use diamond from the galaxy cond env
+
+##module purge
+##module use ...
+##module use diamond/0.9.21
+. /home/berntm/miniconda3/bin/activate '/home/berntm/miniconda3/envs/__diamond@0.9.21'
+
+diamond makedb --in diamonddb/latest/pdbn.fas --taxonmap taxonomy/ncbi/latest/accession2taxid/prot.accession2taxid --taxonnodes taxonomy/ncbi/latest/nodes.dmp --out diamonddb/latest/nr.dmnd
+
+rm /data/db/diamonddb/*.fas

--- a/ncbidb.sh
+++ b/ncbidb.sh
@@ -80,7 +80,6 @@ for i in $DB_NAME*.tar.gz ; do
   rm -f $i $i.md5
 done &&
 log.info "... extracting finished, moving ..." &&
-ls -la &&
 for i in * ; do
   mv -n $i $LOCAL_DIR/$DB_NAME/$DATE/ || exit 1
 done &&


### PR DESCRIPTION
- download remotedir/pattern*.tar.gz from the NCBI ftp to localdir/pattern/YYYY-MM-DD/
  - no sed in pal/nal files necessary
- create latest symlink
- check presence of local dir

TODOs: 
- [ ] decide between workflows:
  1. dl blastdb + dl blastdb-fasta + dl + generate diamond db
  2. dl blastdb-fasta + genrate blastdb and diamond db (only possible for nr, nt)
  - [ ] 1.
- [ ] implementation as 
  1. extra script calling dl+generation program(s)
  2. post-dl operations given as parameter to ncbidl script
  - [ ] 1.
- [ ] decide if dl to localdir/pattern/YYYY-MM-DD/ or localdir/YYYY-MM-DD/ . maybe the latter is better, since local dir can be specified more directly
  - [ ] yep - since then multiple pattterns can go to the same localdir
- [ ] log generate diamond db command line and versions used to db prefix
